### PR TITLE
Added transaction support in jenssegers 3.8.4 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 Laravel MongoDB
 ===============
 
+==================================================**Allbound**====================================================
+```
+Transaction support in MongoDB was added in Release version 3.9.3 of jenssegers/laravel-mongodb. But if we try to switch to this release version, it asks for upgrade to Laravel 9. Since, upgrading to Laravel 9 in api-v5 would be some effort, so for now I have forked the jenssegers/laravel-mongodb repo under our allbound organization.
+
+I have cut a branch named stable out of release version 3.8.4 (The last version before laravel 9 was introduced in jenssegers/laravel-mongodb).
+So now, stable branch of allbound/laravel-mongodb is our master branch which will be referred to in our api-v5 project.
+
+This was the PR https://github.com/jenssegers/laravel-mongodb/pull/2465 in Release 3.9.3 of jenssegers/laravel-mongodb which had the changes for adding Transaction support in MongoDB. I have tried to accomodate transaction support related changes only and ignored the Laravel 9 changes(like adding datatypes to functions and function params etc).
+```
+==================================================**Allbound**=====================================================
+
 [![Latest Stable Version](http://img.shields.io/github/release/jenssegers/laravel-mongodb.svg)](https://packagist.org/packages/jenssegers/mongodb)
 [![Total Downloads](http://img.shields.io/packagist/dm/jenssegers/mongodb.svg)](https://packagist.org/packages/jenssegers/mongodb)
 [![Build Status](https://img.shields.io/github/workflow/status/jenssegers/laravel-mongodb/CI)](https://github.com/jenssegers/laravel-mongodb/actions)

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Jenssegers\Mongodb\Concerns;
+
+use Closure;
+use MongoDB\Client;
+use MongoDB\Driver\Exception\RuntimeException;
+use MongoDB\Driver\Session;
+use function MongoDB\with_transaction;
+use Throwable;
+
+/**
+ * @see https://docs.mongodb.com/manual/core/transactions/
+ */
+trait ManagesTransactions
+{
+    protected ?Session $session = null;
+
+    protected $transactions = 0;
+
+    /**
+     * @return Client
+     */
+    abstract public function getMongoClient();
+
+    public function getSession(): ?Session
+    {
+        return $this->session;
+    }
+
+    private function getSessionOrCreate(): Session
+    {
+        if ($this->session === null) {
+            $this->session = $this->getMongoClient()->startSession();
+        }
+
+        return $this->session;
+    }
+
+    private function getSessionOrThrow(): Session
+    {
+        $session = $this->getSession();
+
+        if ($session === null) {
+            throw new RuntimeException('There is no active session.');
+        }
+
+        return $session;
+    }
+
+    /**
+     * Starts a transaction on the active session. An active session will be created if none exists.
+     */
+    public function beginTransaction(array $options = []): void
+    {
+        $this->getSessionOrCreate()->startTransaction($options);
+        $this->transactions = 1;
+    }
+
+    /**
+     * Commit transaction in this session.
+     */
+    public function commit(): void
+    {
+        $this->getSessionOrThrow()->commitTransaction();
+        $this->transactions = 0;
+    }
+
+    /**
+     * Abort transaction in this session.
+     */
+    public function rollBack($toLevel = null): void
+    {
+        $this->getSessionOrThrow()->abortTransaction();
+        $this->transactions = 0;
+    }
+
+    /**
+     * Static transaction function realize the with_transaction functionality provided by MongoDB.
+     *
+     * @param  int  $attempts
+     */
+    public function transaction(Closure $callback, $attempts = 1, array $options = []): mixed
+    {
+        $attemptsLeft = $attempts;
+        $callbackResult = null;
+        $throwable = null;
+
+        $callbackFunction = function (Session $session) use ($callback, &$attemptsLeft, &$callbackResult, &$throwable) {
+            $attemptsLeft--;
+
+            if ($attemptsLeft < 0) {
+                $session->abortTransaction();
+
+                return;
+            }
+
+            // Catch, store, and re-throw any exception thrown during execution
+            // of the callable. The last exception is re-thrown if the transaction
+            // was aborted because the number of callback attempts has been exceeded.
+            try {
+                $callbackResult = $callback($this);
+            } catch (Throwable $throwable) {
+                throw $throwable;
+            }
+        };
+
+        with_transaction($this->getSessionOrCreate(), $callbackFunction, $options);
+
+        if ($attemptsLeft < 0 && $throwable) {
+            throw $throwable;
+        }
+
+        return $callbackResult;
+    }
+}

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,10 +5,12 @@ namespace Jenssegers\Mongodb;
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Jenssegers\Mongodb\Concerns\ManagesTransactions;
 use MongoDB\Client;
 
 class Connection extends BaseConnection
 {
+    use ManagesTransactions;
     /**
      * The MongoDB database handler.
      * @var \MongoDB\Database


### PR DESCRIPTION
Transaction support in MongoDB was added in Release version 3.9.3 of jenssegers/laravel-mongodb. But if we try to switch to this release version, it asks for upgrade to Laravel 9. Since, upgrading to Laravel 9 in api-v5 would be some effort, so for now I have forked the jenssegers/laravel-mongodb repo under our allbound organization.

I have cut a branch named stable out of release version 3.8.4 (The last version before laravel 9 was introduced in jenssegers/laravel-mongodb).
So now `stable` of allbound/laravel-mongodb is our master branch which will be referred to in our api-v5 project.


This was the PR https://github.com/jenssegers/laravel-mongodb/pull/2465 in Release 3.9.3 of jenssegers/laravel-mongodbwhich had the changes for adding Transaction support in MongoDB. Please refer to this PR to review my changes in the current PR. I have tried to accomodate transaction support related changes only and ignored the Laravel 9 changes(like adding datatypes to functions and function params etc).